### PR TITLE
Use native date pickers and refactor product &sub-product dropdown 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+.DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 replay_pid*
 .DS_Store
 .idea
+/target/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,10 @@
 			<artifactId>postgres-socket-factory</artifactId>
 			<version>1.25.0</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.fos</groupId>
+	<artifactId>reporting</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>reporting</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,17 @@
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.cloud.sql</groupId>
+			<artifactId>postgres-socket-factory</artifactId>
+			<version>1.25.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
@@ -46,11 +57,6 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>42.7.5</version>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,28 +68,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/fos/reporting/ReportingApplication.java
+++ b/src/main/java/com/fos/reporting/ReportingApplication.java
@@ -1,0 +1,13 @@
+package com.fos.reporting;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReportingApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ReportingApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -1,0 +1,21 @@
+package com.fos.reporting.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReportController {
+
+    @GetMapping("/test")
+    public ResponseEntity<String> ping() {
+        try {
+            System.out.println("report service call");
+            return new ResponseEntity<>("test from report service", HttpStatus.OK);
+        } catch (Exception e) {
+            System.out.println("e" + e);
+            return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -2,11 +2,12 @@ package com.fos.reporting.controller;
 
 import com.fos.reporting.domain.CollectionsDto;
 import com.fos.reporting.domain.EntryProduct;
+import com.fos.reporting.domain.GetReportRequest;
+import com.fos.reporting.domain.GetReportResponse;
 import com.fos.reporting.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,7 +56,15 @@ public class ReportController {
             return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
+    @PostMapping("/dashboard-data")
+    public ResponseEntity<GetReportResponse> getDashboardData(@RequestBody @Validated GetReportRequest getReportRequest) {
+        try {
+            return new ResponseEntity<>(reportService.getDashboard(getReportRequest), HttpStatus.OK);
+        } catch (Exception e) {
+            System.out.println("e" + e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 
 }

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -28,11 +28,11 @@ public class ReportController {
         }
     }
 
-    @PostMapping("/product")
+    @PostMapping("/sales")
     public ResponseEntity<String> addEntry(@RequestBody @Validated EntryProduct entryProduct) {
         try {
             reportService.addToSales(entryProduct);
-            return new ResponseEntity<>("test from report service", HttpStatus.OK);
+            return new ResponseEntity<>("added to sales", HttpStatus.OK);
         } catch (Exception e) {
             System.out.println("e" + e);
             return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -6,6 +6,7 @@ import com.fos.reporting.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,4 +55,7 @@ public class ReportController {
             return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+
+
 }

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -1,17 +1,36 @@
 package com.fos.reporting.controller;
 
+import com.fos.reporting.domain.EntryProduct;
+import com.fos.reporting.service.ReportService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class ReportController {
 
+    @Autowired
+    private ReportService reportService;
+
     @GetMapping("/test")
     public ResponseEntity<String> ping() {
         try {
             System.out.println("report service call");
+            return new ResponseEntity<>("test from report service", HttpStatus.OK);
+        } catch (Exception e) {
+            System.out.println("e" + e);
+            return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping("/product")
+    public ResponseEntity<String> addEntry(@RequestBody @Validated EntryProduct entryProduct) {
+        try {
+            reportService.addToSales(entryProduct);
             return new ResponseEntity<>("test from report service", HttpStatus.OK);
         } catch (Exception e) {
             System.out.println("e" + e);

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.fos.reporting.controller;
 
+import com.fos.reporting.domain.CollectionsDto;
 import com.fos.reporting.domain.EntryProduct;
 import com.fos.reporting.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,23 @@ public class ReportController {
     @PostMapping("/sales")
     public ResponseEntity<String> addEntry(@RequestBody @Validated EntryProduct entryProduct) {
         try {
-            reportService.addToSales(entryProduct);
-            return new ResponseEntity<>("added to sales", HttpStatus.OK);
+            if (reportService.addToSales(entryProduct)) {
+                return new ResponseEntity<>("added to sales", HttpStatus.OK);
+            }
+            return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            System.out.println("e" + e);
+            return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/collections")
+    public ResponseEntity<String> addCollections(@RequestBody @Validated CollectionsDto collectionsDto) {
+        try {
+            if (reportService.addToCollections(collectionsDto)) {
+                return new ResponseEntity<>("added to collections", HttpStatus.OK);
+            }
+            return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             System.out.println("e" + e);
             return new ResponseEntity<>("failed exception", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/fos/reporting/controller/ReportController.java
+++ b/src/main/java/com/fos/reporting/controller/ReportController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +28,7 @@ public class ReportController {
         }
     }
 
-    @GetMapping("/product")
+    @PostMapping("/product")
     public ResponseEntity<String> addEntry(@RequestBody @Validated EntryProduct entryProduct) {
         try {
             reportService.addToSales(entryProduct);

--- a/src/main/java/com/fos/reporting/controller/UIController.java
+++ b/src/main/java/com/fos/reporting/controller/UIController.java
@@ -11,8 +11,12 @@ public class UIController {
     public String showSalesForm() {
         return "sales-form";  // refers to templates/sales-form.html
     }
+    @GetMapping("/entry")
+    public String addEntry() {
+        return "entry"; // loads entry-form.html
+    }
     @GetMapping("/dashboard")
-    public String showDashboardForm() {
+    public String showDashboard() {
         return "dashboard"; // loads dashboard-form.html
     }
 

--- a/src/main/java/com/fos/reporting/controller/UIController.java
+++ b/src/main/java/com/fos/reporting/controller/UIController.java
@@ -1,0 +1,24 @@
+package com.fos.reporting.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class UIController {
+
+
+    @GetMapping("/sales-form")
+    public String showSalesForm() {
+        return "sales-form";  // refers to templates/sales-form.html
+    }
+    @GetMapping("/dashboard")
+    public String showDashboardForm() {
+        return "dashboard"; // loads dashboard-form.html
+    }
+
+    @GetMapping("/collections-form")
+    public String showCollectionsForm() {
+        return "collections-form"; // maps to collections-form.html
+    }
+
+}

--- a/src/main/java/com/fos/reporting/domain/CollectionsDto.java
+++ b/src/main/java/com/fos/reporting/domain/CollectionsDto.java
@@ -1,0 +1,30 @@
+package com.fos.reporting.domain;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CollectionsDto {
+    @NotNull
+    private String date;
+    @NotNull
+    private int employeeId;
+    private float cashReceived;
+    private String cashReceivedStatus;
+    private float phonePay;
+    private String phonePayStatus;
+    private float creditCard;
+    private String creditCardStatus;
+    private float borrowedAmount;
+    private float debtRecovered;
+    private String borrower;
+    private float badHandling;
+    private float expenses;
+}

--- a/src/main/java/com/fos/reporting/domain/EntryProduct.java
+++ b/src/main/java/com/fos/reporting/domain/EntryProduct.java
@@ -1,0 +1,17 @@
+package com.fos.reporting.domain;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EntryProduct {
+
+    private String date;
+    private List<Product> products;
+    private int employeeId;
+}

--- a/src/main/java/com/fos/reporting/domain/EntryProduct.java
+++ b/src/main/java/com/fos/reporting/domain/EntryProduct.java
@@ -1,20 +1,30 @@
 package com.fos.reporting.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Data
-@Setter
-@Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class EntryProduct {
 
+    /** Binds "YYYY-MM-DD" JSON strings into a LocalDate */
     @NotNull
-    private String date;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    /** Employee ID from the form */
+    @NotNull
+    private Integer employeeId;
+
+    /** List of products (petrol/diesel/etc.) */
+    @NotNull
     private List<Product> products;
-    @NotNull
-    private int employeeId;
 }
+

--- a/src/main/java/com/fos/reporting/domain/EntryProduct.java
+++ b/src/main/java/com/fos/reporting/domain/EntryProduct.java
@@ -1,5 +1,6 @@
 package com.fos.reporting.domain;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.List;
@@ -11,7 +12,9 @@ import java.util.List;
 @NoArgsConstructor
 public class EntryProduct {
 
+    @NotNull
     private String date;
     private List<Product> products;
+    @NotNull
     private int employeeId;
 }

--- a/src/main/java/com/fos/reporting/domain/GetReportRequest.java
+++ b/src/main/java/com/fos/reporting/domain/GetReportRequest.java
@@ -1,0 +1,17 @@
+package com.fos.reporting.domain;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetReportRequest {
+    @NotNull
+    private String fromDate;
+    @NotNull
+    private String toDate;
+
+}

--- a/src/main/java/com/fos/reporting/domain/GetReportResponse.java
+++ b/src/main/java/com/fos/reporting/domain/GetReportResponse.java
@@ -1,0 +1,16 @@
+package com.fos.reporting.domain;
+
+import lombok.*;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetReportResponse {
+
+    private float actualCollection;
+    private float difference;
+    private ReportData petrol;
+    private ReportData diesel;
+}

--- a/src/main/java/com/fos/reporting/domain/Product.java
+++ b/src/main/java/com/fos/reporting/domain/Product.java
@@ -1,5 +1,6 @@
 package com.fos.reporting.domain;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Data
@@ -8,12 +9,11 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Product {
-
-
-    private String product;
-    private int closing;
-    private int price;
-    private int testing;
-
-
+    @NotNull
+    private String productName;
+    private String subProduct;
+    private float closing;
+    @NotNull
+    private float price;
+    private float testing;
 }

--- a/src/main/java/com/fos/reporting/domain/Product.java
+++ b/src/main/java/com/fos/reporting/domain/Product.java
@@ -1,20 +1,45 @@
 package com.fos.reporting.domain;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ * Mirrors the JSON:
+ * { "productName":"…", "subProduct":"…", "opening":0.0, "closing":0.0,
+ *   "price":0.0, "testing":0.0 }
+ */
 @Data
-@Setter
-@Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Product {
-    @NotNull
-    private String productName;
-    private String subProduct;
-    private float closing;
-    private float opening;
-    @NotNull
-    private float price;
-    private float testing;
+  
+  /** e.g. "petrol", "diesel", "other" */
+  @NotNull
+  @JsonProperty("productName")
+  private String productName;
+
+  /** e.g. "G1", "G2", "G3" */
+  @JsonProperty("subProduct")
+  private String subProduct;
+
+  /** opening stock (may default to 0 if missing) */
+  @JsonProperty("opening")
+  private Float opening = 0f;
+
+  /** closing stock */
+  @JsonProperty("closing")
+  private Float closing = 0f;
+
+  /** price per unit (required) */
+  @NotNull
+  @JsonProperty("price")
+  private Float price;
+
+  /** testing amount (may default to 0 if missing) */
+  @JsonProperty("testing")
+  private Float testing = 0f;
 }
+

--- a/src/main/java/com/fos/reporting/domain/Product.java
+++ b/src/main/java/com/fos/reporting/domain/Product.java
@@ -13,6 +13,7 @@ public class Product {
     private String productName;
     private String subProduct;
     private float closing;
+    private float opening;
     @NotNull
     private float price;
     private float testing;

--- a/src/main/java/com/fos/reporting/domain/Product.java
+++ b/src/main/java/com/fos/reporting/domain/Product.java
@@ -1,0 +1,19 @@
+package com.fos.reporting.domain;
+
+import lombok.*;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Product {
+
+
+    private String product;
+    private int closing;
+    private int price;
+    private int testing;
+
+
+}

--- a/src/main/java/com/fos/reporting/domain/ReportData.java
+++ b/src/main/java/com/fos/reporting/domain/ReportData.java
@@ -1,0 +1,14 @@
+package com.fos.reporting.domain;
+
+import lombok.*;
+
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReportData {
+    private float saleInLtr;
+    private float expectedCollections;
+}

--- a/src/main/java/com/fos/reporting/entity/Collections.java
+++ b/src/main/java/com/fos/reporting/entity/Collections.java
@@ -18,7 +18,7 @@ public class Collections {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private LocalDateTime dateTime;
-    private float employeeId;
+    private int employeeId;
     private float cashReceived;
     private float phonePay;
     private float creditCard;

--- a/src/main/java/com/fos/reporting/entity/Collections.java
+++ b/src/main/java/com/fos/reporting/entity/Collections.java
@@ -1,0 +1,27 @@
+package com.fos.reporting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "collections")
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Collections {
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO)
+    private Long id;
+    private LocalDateTime dateTime;
+    private int employeeId;
+    private int cash;
+    private int phonePay;
+    private int cc;
+    private int debt;
+    private int badHandling;
+    private int amountUsed;
+}

--- a/src/main/java/com/fos/reporting/entity/Collections.java
+++ b/src/main/java/com/fos/reporting/entity/Collections.java
@@ -12,16 +12,22 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class Collections {
     @Id
-    @GeneratedValue(strategy= GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private LocalDateTime dateTime;
-    private int employeeId;
-    private int cash;
-    private int phonePay;
-    private int cc;
-    private int debt;
-    private int badHandling;
-    private int amountUsed;
+    private float employeeId;
+    private float cashReceived;
+    private float phonePay;
+    private float creditCard;
+    private float borrowedAmount;
+    private float debtRecovered;
+    private String borrower;
+    private float badHandling;
+    private float expenses;
+    private double expectedTotal;
+    private double receivedTotal;
+    private double difference;
 }

--- a/src/main/java/com/fos/reporting/entity/Sales.java
+++ b/src/main/java/com/fos/reporting/entity/Sales.java
@@ -1,6 +1,7 @@
 package com.fos.reporting.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,8 +17,10 @@ public class Sales {
     @Id
     @GeneratedValue(strategy= GenerationType.AUTO)
     private Long id;
+    @NotNull
     private LocalDateTime dateTime;
     private int productId;
+    @NotNull
     private int employeeId;
     private int openingStock;
     private int closingStock;

--- a/src/main/java/com/fos/reporting/entity/Sales.java
+++ b/src/main/java/com/fos/reporting/entity/Sales.java
@@ -19,13 +19,15 @@ public class Sales {
     private Long id;
     @NotNull
     private LocalDateTime dateTime;
-    private int productId;
+    @NotNull
+    private String productName;
+    private String subProduct;
     @NotNull
     private int employeeId;
-    private int openingStock;
-    private int closingStock;
-    private int testingTotal;
-    private int sale;
-    private int cost;
-    private int inventory;
+    private float openingStock;
+    private float closingStock;
+    private float testingTotal;
+    private float sale;
+    private float price;
+    private float saleAmount;
 }

--- a/src/main/java/com/fos/reporting/entity/Sales.java
+++ b/src/main/java/com/fos/reporting/entity/Sales.java
@@ -1,0 +1,28 @@
+package com.fos.reporting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "sales")
+@Data
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Sales {
+    @Id
+    @GeneratedValue(strategy= GenerationType.AUTO)
+    private Long id;
+    private LocalDateTime dateTime;
+    private int productId;
+    private int employeeId;
+    private int openingStock;
+    private int closingStock;
+    private int testingTotal;
+    private int sale;
+    private int cost;
+    private int inventory;
+}

--- a/src/main/java/com/fos/reporting/repository/CollectionsRepository.java
+++ b/src/main/java/com/fos/reporting/repository/CollectionsRepository.java
@@ -1,0 +1,8 @@
+package com.fos.reporting.repository;
+
+import com.fos.reporting.entity.Collections;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CollectionsRepository extends JpaRepository<Collections, Long> {
+
+}

--- a/src/main/java/com/fos/reporting/repository/CollectionsRepository.java
+++ b/src/main/java/com/fos/reporting/repository/CollectionsRepository.java
@@ -1,8 +1,14 @@
 package com.fos.reporting.repository;
 
 import com.fos.reporting.entity.Collections;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface CollectionsRepository extends JpaRepository<Collections, Long> {
+
+    List<Collections> findByDateTimeBetween(LocalDateTime fromDate, LocalDateTime toDate);
 
 }

--- a/src/main/java/com/fos/reporting/repository/SalesRepository.java
+++ b/src/main/java/com/fos/reporting/repository/SalesRepository.java
@@ -12,4 +12,6 @@ public interface SalesRepository extends JpaRepository<Sales, Long> {
     Sales findTopByProductNameAndSubProductOrderByDateTimeDesc(@NotNull String productName, String subProduct);
 
     List<Sales> findByDateTime(@NotNull LocalDateTime datetime);
+
+    List<Sales> findByDateTimeBetween(@NotNull LocalDateTime fromDate, @NotNull LocalDateTime toDate);
 }

--- a/src/main/java/com/fos/reporting/repository/SalesRepository.java
+++ b/src/main/java/com/fos/reporting/repository/SalesRepository.java
@@ -4,7 +4,12 @@ import com.fos.reporting.entity.Sales;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface SalesRepository extends JpaRepository<Sales, Long> {
 
-    Sales  findTopByProductNameAndSubProductOrderByDateTimeDesc(@NotNull String productName, String subProduct);
+    Sales findTopByProductNameAndSubProductOrderByDateTimeDesc(@NotNull String productName, String subProduct);
+
+    List<Sales> findByDateTime(@NotNull LocalDateTime datetime);
 }

--- a/src/main/java/com/fos/reporting/repository/SalesRepository.java
+++ b/src/main/java/com/fos/reporting/repository/SalesRepository.java
@@ -1,0 +1,7 @@
+package com.fos.reporting.repository;
+
+import com.fos.reporting.entity.Sales;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SalesRepository extends JpaRepository<Sales, Long> {
+}

--- a/src/main/java/com/fos/reporting/repository/SalesRepository.java
+++ b/src/main/java/com/fos/reporting/repository/SalesRepository.java
@@ -1,7 +1,10 @@
 package com.fos.reporting.repository;
 
 import com.fos.reporting.entity.Sales;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SalesRepository extends JpaRepository<Sales, Long> {
+
+    Sales  findTopByProductNameAndSubProductOrderByDateTimeDesc(@NotNull String productName, String subProduct);
 }

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Service
 public class ReportService {
 
@@ -16,6 +18,8 @@ public class ReportService {
         try {
         entryProduct.getProducts().forEach(product -> {
             Sales sales = new Sales();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
+            sales.setDateTime(LocalDateTime.parse(entryProduct.getDate(), formatter) );
             sales.setEmployeeId(entryProduct.getEmployeeId());
             sales.setClosingStock(product.getClosing());
             sales.setTestingTotal(product.getTesting());

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -1,13 +1,18 @@
 package com.fos.reporting.service;
 
+import com.fos.reporting.domain.CollectionsDto;
 import com.fos.reporting.domain.EntryProduct;
+import com.fos.reporting.entity.Collections;
 import com.fos.reporting.entity.Sales;
+import com.fos.reporting.repository.CollectionsRepository;
 import com.fos.reporting.repository.SalesRepository;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 public class ReportService {
@@ -15,6 +20,8 @@ public class ReportService {
 
     @Autowired
     private SalesRepository salesRepository;
+    @Autowired
+    private CollectionsRepository collectionsRepository;
     public boolean addToSales(EntryProduct entryProduct) {
         try {
         entryProduct.getProducts().forEach(product -> {
@@ -23,15 +30,17 @@ public class ReportService {
             sales.setProductName(product.getProductName());
             sales.setSubProduct(product.getSubProduct());
             sales.setEmployeeId(entryProduct.getEmployeeId());
-            Sales recentSale = salesRepository.findTopByProductNameAndSubProductOrderByDateTimeDesc(sales.getProductName(),sales.getSubProduct());
-            sales.setClosingStock(product.getClosing());
-            float closingStock = 0;
-            if (recentSale != null) {
-                closingStock = recentSale.getClosingStock();
+            float opening = product.getOpening();
+            if (product.getOpening() == 0) {
+                Sales recentSale = salesRepository.findTopByProductNameAndSubProductOrderByDateTimeDesc(sales.getProductName(), sales.getSubProduct());
+                if (recentSale != null) {
+                    opening = recentSale.getClosingStock();
+                }
             }
-            sales.setOpeningStock(closingStock);
+            sales.setClosingStock(product.getClosing());
+            sales.setOpeningStock(opening);
             sales.setTestingTotal(product.getTesting());
-            float sale = product.getClosing() - closingStock - product.getTesting();
+            float sale = product.getClosing() - opening - product.getTesting();
             sales.setSale(sale);
             sales.setPrice(product.getPrice());
             sales.setSaleAmount(sale * product.getPrice());
@@ -39,8 +48,39 @@ public class ReportService {
         });
             return true;
         }catch (Exception e) {
-            System.err.println(e);
+            e.printStackTrace();
             return false;
         }
+    }
+
+    public boolean addToCollections(CollectionsDto collectionsDto) {
+        try {
+            Collections collections = mapToCollections(collectionsDto);
+            LocalDateTime requestedTime = LocalDateTime.parse(collectionsDto.getDate(), formatter);
+            List<Sales> salesByTime = salesRepository.findByDateTime(requestedTime);
+            double expectedTotal = salesByTime.stream().map(Sales::getSaleAmount)
+                    .mapToDouble(Float::doubleValue).sum();
+            double receivedTotal = collectionsDto.getCashReceived() +
+                    collectionsDto.getPhonePay() +
+                    collectionsDto.getCreditCard() +
+                    collectionsDto.getBorrowedAmount() +
+                    collectionsDto.getDebtRecovered() +
+                    collectionsDto.getExpenses();
+            collections.setExpectedTotal(expectedTotal);
+            collections.setReceivedTotal(receivedTotal);
+            collections.setDifference(expectedTotal - receivedTotal);
+            Collections save = collectionsRepository.save(collections);
+            return save.getId() > 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private Collections mapToCollections(CollectionsDto collectionsDto) {
+        Collections collections = new Collections();
+        BeanUtils.copyProperties(collectionsDto,collections);
+        collections.setDateTime(LocalDateTime.parse(collectionsDto.getDate(), formatter));
+        return collections;
     }
 }

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -1,0 +1,34 @@
+package com.fos.reporting.service;
+
+import com.fos.reporting.domain.EntryProduct;
+import com.fos.reporting.entity.Sales;
+import com.fos.reporting.repository.SalesRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+@Service
+public class ReportService {
+
+    @Autowired
+    private SalesRepository salesRepository;
+    public boolean addToSales(EntryProduct entryProduct) {
+        try {
+        entryProduct.getProducts().forEach(product -> {
+            Sales sales = new Sales();
+            sales.setEmployeeId(entryProduct.getEmployeeId());
+            sales.setClosingStock(product.getClosing());
+            sales.setTestingTotal(product.getTesting());
+          //  sales.setSale(product)
+            sales.setCost(product.getPrice());
+            //sales.setInventory(product.get)
+
+            salesRepository.save(sales);
+        });
+            return true;
+        }catch (Exception e) {
+            System.err.println(e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -1,6 +1,11 @@
 package com.fos.reporting.service;
 
-import com.fos.reporting.domain.*;
+import com.fos.reporting.domain.CollectionsDto;
+import com.fos.reporting.domain.EntryProduct;
+import com.fos.reporting.domain.GetReportRequest;
+import com.fos.reporting.domain.GetReportResponse;
+import com.fos.reporting.domain.Product;
+import com.fos.reporting.domain.ReportData;
 import com.fos.reporting.entity.Collections;
 import com.fos.reporting.entity.Sales;
 import com.fos.reporting.repository.CollectionsRepository;
@@ -15,99 +20,146 @@ import java.util.List;
 
 @Service
 public class ReportService {
-    public static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss a");
+    // Used for parsing your CollectionsDto and GetReportRequest dates
+    private static final DateTimeFormatter DATE_TIME_FMT =
+        DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
 
     @Autowired
     private SalesRepository salesRepository;
+
     @Autowired
     private CollectionsRepository collectionsRepository;
+
     public boolean addToSales(EntryProduct entryProduct) {
         try {
-        entryProduct.getProducts().forEach(product -> {
-            Sales sales = new Sales();
-            sales.setDateTime(LocalDateTime.parse(entryProduct.getDate(), formatter));
-            sales.setProductName(product.getProductName());
-            sales.setSubProduct(product.getSubProduct());
-            sales.setEmployeeId(entryProduct.getEmployeeId());
-            float opening = product.getOpening();
-            if (product.getOpening() == 0) {
-                Sales recentSale = salesRepository.findTopByProductNameAndSubProductOrderByDateTimeDesc(sales.getProductName(), sales.getSubProduct());
-                if (recentSale != null) {
-                    opening = recentSale.getClosingStock();
-                }
-            }
-            sales.setClosingStock(product.getClosing());
-            sales.setOpeningStock(opening);
-            sales.setTestingTotal(product.getTesting());
-            float sale = product.getClosing() - opening - product.getTesting();
-            sales.setSale(sale);
-            sales.setPrice(product.getPrice());
-            sales.setSaleAmount(sale * product.getPrice());
-            salesRepository.save(sales);
-        });
-            return true;
-        }catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
+            // entryProduct.getDate() is a LocalDate; convert to DateTime at start of day
+            LocalDateTime saleDateTime = entryProduct.getDate().atStartOfDay();
 
-    public boolean addToCollections(CollectionsDto collectionsDto) {
-        try {
-            Collections collections = mapToCollections(collectionsDto);
-            LocalDateTime requestedTime = LocalDateTime.parse(collectionsDto.getDate(), formatter);
-            collections.setEmployeeId(collections.getEmployeeId());
-            List<Sales> salesByTime = salesRepository.findByDateTime(requestedTime);
-            double expectedTotal = salesByTime.stream().map(Sales::getSaleAmount)
-                    .mapToDouble(Float::doubleValue).sum();
-            double receivedTotal = collectionsDto.getCashReceived() +
-                    collectionsDto.getPhonePay() +
-                    collectionsDto.getCreditCard() +
-                    collectionsDto.getBorrowedAmount() +
-                    collectionsDto.getDebtRecovered() +
-                    collectionsDto.getExpenses();
-            collections.setExpectedTotal(expectedTotal);
-            collections.setReceivedTotal(receivedTotal);
-            collections.setDifference(expectedTotal - receivedTotal);
-            Collections save = collectionsRepository.save(collections);
-            return save.getId() > 0;
+            for (Product product : entryProduct.getProducts()) {
+                Sales sales = new Sales();
+
+                // 1) Set timestamp
+                sales.setDateTime(saleDateTime);
+
+                // 2) Employee & product info
+                sales.setEmployeeId(entryProduct.getEmployeeId());
+                sales.setProductName(product.getProductName());
+                sales.setSubProduct(product.getSubProduct());
+
+                // 3) Determine openingStock fallback if zero
+                float opening = product.getOpening();
+                if (opening == 0f) {
+                    Sales recent = salesRepository
+                      .findTopByProductNameAndSubProductOrderByDateTimeDesc(
+                          sales.getProductName(),
+                          sales.getSubProduct());
+                    if (recent != null) {
+                        opening = recent.getClosingStock();
+                    }
+                }
+                sales.setOpeningStock(opening);
+
+                // 4) The rest of the fields
+                sales.setClosingStock(product.getClosing());
+                sales.setTestingTotal(product.getTesting());
+                float sale = product.getClosing() - opening - product.getTesting();
+                sales.setSale(sale);
+                sales.setPrice(product.getPrice());
+                sales.setSaleAmount(sale * product.getPrice());
+
+                // 5) Persist
+                salesRepository.save(sales);
+            }
+            return true;
         } catch (Exception e) {
             e.printStackTrace();
             return false;
         }
     }
 
-    private Collections mapToCollections(CollectionsDto collectionsDto) {
-        Collections collections = new Collections();
-        BeanUtils.copyProperties(collectionsDto,collections);
-        collections.setDateTime(LocalDateTime.parse(collectionsDto.getDate(), formatter));
-        return collections;
+    public boolean addToCollections(CollectionsDto dto) {
+        try {
+            Collections coll = mapToCollections(dto);
+
+            LocalDateTime timestamp = LocalDateTime.parse(dto.getDate(), DATE_TIME_FMT);
+            coll.setDateTime(timestamp);
+
+            List<Sales> salesList = salesRepository.findByDateTime(timestamp);
+            double expectedTotal = salesList.stream()
+                .map(Sales::getSaleAmount)
+                .mapToDouble(Float::doubleValue)
+                .sum();
+
+            double receivedTotal = dto.getCashReceived()
+                + dto.getPhonePay()
+                + dto.getCreditCard()
+                + dto.getBorrowedAmount()
+                + dto.getDebtRecovered()
+                + dto.getExpenses();
+
+            coll.setExpectedTotal(expectedTotal);
+            coll.setReceivedTotal(receivedTotal);
+            coll.setDifference(expectedTotal - receivedTotal);
+
+            return collectionsRepository.save(coll).getId() > 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private Collections mapToCollections(CollectionsDto dto) {
+        Collections c = new Collections();
+        BeanUtils.copyProperties(dto, c);
+        c.setDateTime(LocalDateTime.parse(dto.getDate(), DATE_TIME_FMT));
+        return c;
     }
 
     public GetReportResponse getDashboard(GetReportRequest req) {
-        GetReportResponse getReportResponse = new GetReportResponse();
-        LocalDateTime fromDate = LocalDateTime.parse(req.getFromDate(), formatter);
-        LocalDateTime toDate = LocalDateTime.parse(req.getToDate(), formatter);
-        List<Collections> collections = collectionsRepository.findByDateTimeBetween(fromDate, toDate);
-        List<Sales> sales = salesRepository.findByDateTimeBetween(fromDate, toDate);
-        float petrol = (float) getSalesByProductName(sales, "petrol");
-        float diesel = (float) getSalesByProductName(sales, "diesel");
-        float petrolCollections = (float) getCollections(sales, "petrol");
-        float dieselCollections = (float) getCollections(sales, "diesel");
-        float actualCollections = (float) collections.stream().map(Collections::getReceivedTotal).mapToDouble(x -> x).sum();
-        getReportResponse.setActualCollection(actualCollections);
-        getReportResponse.setDifference(petrolCollections + dieselCollections - actualCollections);
-        getReportResponse.setPetrol(ReportData.builder().saleInLtr(petrol).expectedCollections(petrolCollections).build());
-        getReportResponse.setDiesel(ReportData.builder().saleInLtr(diesel).expectedCollections(dieselCollections).build());
-        return getReportResponse;
-    }
+        GetReportResponse resp = new GetReportResponse();
+        LocalDateTime from = LocalDateTime.parse(req.getFromDate(), DATE_TIME_FMT);
+        LocalDateTime to   = LocalDateTime.parse(req.getToDate(),   DATE_TIME_FMT);
 
-    private static double getSalesByProductName(List<Sales> sales,String productName) {
-        return sales.stream().filter(x -> productName.equalsIgnoreCase(x.getProductName())).
-                map(Sales::getSale).mapToDouble(x -> x).sum();
-    }
-    private static double getCollections(List<Sales> sales,String productName) {
-        return sales.stream().filter(x -> productName.equalsIgnoreCase(x.getProductName())).
-                map(Sales::getSaleAmount).mapToDouble(x -> x).sum();
+        List<Collections> collList = collectionsRepository.findByDateTimeBetween(from, to);
+        List<Sales>       salesList = salesRepository.findByDateTimeBetween(from, to);
+
+        // Total liters sold
+        double petrolLiters = salesList.stream()
+            .filter(s -> "petrol".equalsIgnoreCase(s.getProductName()))
+            .mapToDouble(s -> s.getSale())  // sale = closingStock - openingStock - testingTotal
+            .sum();
+        double dieselLiters = salesList.stream()
+            .filter(s -> "diesel".equalsIgnoreCase(s.getProductName()))
+            .mapToDouble(Sales::getSale)
+            .sum();
+
+        // Expected collections (saleAmount)
+        double petrolColl = salesList.stream()
+            .filter(s -> "petrol".equalsIgnoreCase(s.getProductName()))
+            .mapToDouble(Sales::getSaleAmount)
+            .sum();
+        double dieselColl = salesList.stream()
+            .filter(s -> "diesel".equalsIgnoreCase(s.getProductName()))
+            .mapToDouble(Sales::getSaleAmount)
+            .sum();
+
+        // Actual collected
+        double actual = collList.stream()
+            .mapToDouble(Collections::getReceivedTotal)
+            .sum();
+
+        resp.setActualCollection((float) actual);
+        resp.setDifference((float)(petrolColl + dieselColl - actual));
+
+        resp.setPetrol(ReportData.builder()
+            .saleInLtr((float) petrolLiters)
+            .expectedCollections((float) petrolColl)
+            .build());
+        resp.setDiesel(ReportData.builder()
+            .saleInLtr((float) dieselLiters)
+            .expectedCollections((float) dieselColl)
+            .build());
+
+        return resp;
     }
 }

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @Service
 public class ReportService {
-    public static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
+    public static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss a");
 
     @Autowired
     private SalesRepository salesRepository;

--- a/src/main/java/com/fos/reporting/service/ReportService.java
+++ b/src/main/java/com/fos/reporting/service/ReportService.java
@@ -57,6 +57,7 @@ public class ReportService {
         try {
             Collections collections = mapToCollections(collectionsDto);
             LocalDateTime requestedTime = LocalDateTime.parse(collectionsDto.getDate(), formatter);
+            collections.setEmployeeId(collections.getEmployeeId());
             List<Sales> salesByTime = salesRepository.findByDateTime(requestedTime);
             double expectedTotal = salesByTime.stream().map(Sales::getSaleAmount)
                     .mapToDouble(Float::doubleValue).sum();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.datasource.url=jdbc:postgresql://google/reporting?cloudSqlInstance=rare-gist-459620-t5:us-central1:fos&socketFactory=com.google.cloud.sql.postgres.SocketFactory
-
 spring.datasource.username=admin
 spring.datasource.password=admin
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
-spring.datasource.url=jdbc:postgresql://34.10.120.209:5432/reporting
+spring.datasource.url=jdbc:postgresql://google/reporting?cloudSqlInstance=rare-gist-459620-t5:us-central1:fos&socketFactory=com.google.cloud.sql.postgres.SocketFactory
+
 spring.datasource.username=admin
 spring.datasource.password=admin
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+spring.datasource.url=jdbc:postgresql://34.10.120.209:5432/reporting
+spring.datasource.username=admin
+spring.datasource.password=admin
+
+# Optional settings
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/templates/collections-form.html
+++ b/src/main/resources/templates/collections-form.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Collections Entry</title>
+    <script>
+        function submitCollectionsForm(event) {
+            event.preventDefault();
+
+            const data = {
+                date: document.getElementById("date").value,
+                employeeId: parseInt(document.getElementById("employeeId").value),
+                cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
+                cashReceivedStatus: document.getElementById("cashReceivedStatus").value,
+                phonePay: parseFloat(document.getElementById("phonePay").value || 0),
+                phonePayStatus: document.getElementById("phonePayStatus").value,
+                creditCard: parseFloat(document.getElementById("creditCard").value || 0),
+                creditCardStatus: document.getElementById("creditCardStatus").value,
+                borrowedAmount: parseFloat(document.getElementById("borrowedAmount").value || 0),
+                debtRecovered: parseFloat(document.getElementById("debtRecovered").value || 0),
+                borrower: document.getElementById("borrower").value,
+                badHandling: parseFloat(document.getElementById("badHandling").value || 0),
+                expenses: parseFloat(document.getElementById("expenses").value || 0)
+            };
+
+            fetch('/collections', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            })
+            .then(response => response.text())
+            .then(msg => alert("Submitted: " + msg))
+            .catch(err => alert("Error: " + err));
+        }
+    </script>
+</head>
+<body>
+<h1>Collections Entry</h1>
+
+<form id="collectionsForm" onsubmit="submitCollectionsForm(event)">
+    <label>Date:</label>
+    <input type="text" id="date" required><br>
+
+    <label>Employee ID:</label>
+    <input type="number" id="employeeId" required><br>
+
+    <label>Cash Received:</label>
+    <input type="number" step="any" id="cashReceived"><br>
+
+    <label>Cash Received Status:</label>
+    <input type="text" id="cashReceivedStatus"><br>
+
+    <label>PhonePay:</label>
+    <input type="number" step="any" id="phonePay"><br>
+
+    <label>PhonePay Status:</label>
+    <input type="text" id="phonePayStatus"><br>
+
+    <label>Credit Card:</label>
+    <input type="number" step="any" id="creditCard"><br>
+
+    <label>Credit Card Status:</label>
+    <input type="text" id="creditCardStatus"><br>
+
+    <label>Borrowed Amount:</label>
+    <input type="number" step="any" id="borrowedAmount"><br>
+
+    <label>Debt Recovered:</label>
+    <input type="number" step="any" id="debtRecovered"><br>
+
+    <label>Borrower:</label>
+    <input type="text" id="borrower"><br>
+
+    <label>Bad Handling:</label>
+    <input type="number" step="any" id="badHandling"><br>
+
+    <label>Expenses:</label>
+    <input type="number" step="any" id="expenses"><br><br>
+
+    <button type="submit">Submit</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,32 +1,68 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Dashboard Entry</title>
+    <title>Sales & Collections Entry</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <script>
+         function addProductRow() {
+        const container = document.getElementById("products");
+        const div = document.createElement("div");
+        div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
+
+        div.innerHTML = `
+            <div class="col-md-4">
+                <input type="text" class="form-control" placeholder="Product Name" required>
+            </div>
+            <div class="col-md-4">
+                <input type="text" class="form-control" placeholder="Sub Product">
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="any" class="form-control" placeholder="Opening">
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="any" class="form-control" placeholder="Closing">
+            </div>
+            <div class="col-md-4">
+                <input type="number" step="any" class="form-control" placeholder="Price" required>
+            </div>
+            <div class="col-md-4">
+                <input type="number" step="any" class="form-control" placeholder="Testing">
+            </div>
+            <div class="col-md-4 text-end">
+                <button type="button" class="btn btn-outline-danger btn-sm mt-2" onclick="removeProductRow(this)">Remove</button>
+            </div>
+        `;
+
+        container.appendChild(div);
+    }
+
+    function removeProductRow(button) {
+        button.closest('.product-group').remove();
+    }
+
         function collectProducts() {
-            const productGroups = document.querySelectorAll(".product-group");
+            const groups = document.querySelectorAll(".product-group");
             const products = [];
 
-            productGroups.forEach(group => {
+            groups.forEach(group => {
                 const inputs = group.querySelectorAll("input");
-                const product = {
+                products.push({
                     productName: inputs[0].value,
                     subProduct: inputs[1].value,
                     opening: parseFloat(inputs[2].value || 0),
                     closing: parseFloat(inputs[3].value || 0),
                     price: parseFloat(inputs[4].value),
                     testing: parseFloat(inputs[5].value || 0)
-                };
-                products.push(product);
+                });
             });
 
             return products;
         }
 
-        function submitSalesForm(event) {
+        function submitSales(event) {
+        
             event.preventDefault();
-
-            const salesData = {
+            const data = {
                 date: document.getElementById("salesDate").value,
                 employeeId: parseInt(document.getElementById("salesEmployeeId").value),
                 products: collectProducts()
@@ -35,17 +71,15 @@
             fetch('/sales', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(salesData)
-            })
-            .then(res => res.text())
-            .then(msg => alert("Sales Submitted: " + msg))
-            .catch(err => alert("Sales Error: " + err));
+                body: JSON.stringify(data)
+            }).then(res => res.text())
+              .then(msg => alert("Sales Saved: " + msg))
+              .catch(err => alert("Error: " + err));
         }
 
-        function submitCollectionsForm(event) {
+        function submitCollections(event) {
             event.preventDefault();
-
-            const collectionsData = {
+            const data = {
                 date: document.getElementById("collectionsDate").value,
                 employeeId: parseInt(document.getElementById("collectionsEmployeeId").value),
                 cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
@@ -64,100 +98,70 @@
             fetch('/collections', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(collectionsData)
-            })
-            .then(res => res.text())
-            .then(msg => alert("Collections Submitted: " + msg))
-            .catch(err => alert("Collections Error: " + err));
+                body: JSON.stringify(data)
+            }).then(res => res.text())
+              .then(msg => alert("Collections Saved: " + msg))
+              .catch(err => alert("Error: " + err));
         }
 
-        function addProductRow() {
-            const container = document.getElementById("products");
-
-            const div = document.createElement("div");
-            div.className = "product-group";
-            div.innerHTML = `
-                <hr>
-                <label>Product Name:</label>
-                <input type="text" required><br>
-                <label>Sub Product:</label>
-                <input type="text"><br>
-                <label>Opening:</label>
-                <input type="number" step="any"><br>
-                <label>Closing:</label>
-                <input type="number" step="any"><br>
-                <label>Price:</label>
-                <input type="number" step="any" required><br>
-                <label>Testing:</label>
-                <input type="number" step="any"><br>
-            `;
-            container.appendChild(div);
-        }
-
-        window.onload = () => {
-            addProductRow(); // default one product row
-        };
+        window.onload = () => addProductRow();
     </script>
 </head>
-<body>
+<body class="bg-body-tertiary">
 
-<h1>Dashboard Entry</h1>
+<div class="container py-4">
+    <h2 class="mb-4">Sales & Collections Dashboard</h2>
 
-<!-- Sales Entry Form -->
-<h2>Sales Entry</h2>
-<form id="salesForm" onsubmit="submitSalesForm(event)">
-    <label>Date:</label>
-    <input type="text" id="salesDate" required><br>
+    <!-- Sales Form -->
+    <form onsubmit="submitSales(event)" class="mb-5 border p-4 rounded bg-white shadow-sm">
+        <h4>Sales Entry</h4>
+        <div class="row g-3 mb-3">
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="salesDate" placeholder="Date" required>
+            </div>
+            <div class="col-md-6">
+                <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
+            </div>
+        </div>
 
-    <label>Employee ID:</label>
-    <input type="number" id="salesEmployeeId" required><br>
+        <div id="products"></div>
+        <button type="button" class="btn btn-outline-primary mt-2" onclick="addProductRow()">Add Product</button>
+        <button type="submit" class="btn btn-success mt-2 float-end">Submit Sales</button>
+    </form>
 
-    <div id="products"></div>
-    <button type="button" onclick="addProductRow()">Add Product</button><br><br>
+    <!-- Collections Form -->
+    <form onsubmit="submitCollections(event)" class="border p-4 rounded bg-white shadow-sm">
+        <h4>Collections Entry</h4>
+        <div class="row g-3 mb-3">
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="collectionsDate" placeholder="Date" required>
+            </div>
+            <div class="col-md-6">
+                <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
+            </div>
+        </div>
 
-    <button type="submit">Submit Sales</button>
-</form>
+        <div class="row g-3 mb-3">
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status"></div>
 
-<hr>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status"></div>
 
-<!-- Collections Entry Form -->
-<h2>Collections Entry</h2>
-<form id="collectionsForm" onsubmit="submitCollectionsForm(event)">
-    <label>Date:</label>
-    <input type="text" id="collectionsDate" required><br>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status"></div>
 
-    <label>Employee ID:</label>
-    <input type="number" id="collectionsEmployeeId" required><br>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered"></div>
 
-    <label>Cash Received:</label>
-    <input type="number" step="any" id="cashReceived"><br>
-    <label>Cash Received Status:</label>
-    <input type="text" id="cashReceivedStatus"><br>
+            <div class="col-md-6"><input type="text" class="form-control" id="borrower" placeholder="Borrower Name"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses"></div>
+        </div>
 
-    <label>PhonePay:</label>
-    <input type="number" step="any" id="phonePay"><br>
-    <label>PhonePay Status:</label>
-    <input type="text" id="phonePayStatus"><br>
-
-    <label>Credit Card:</label>
-    <input type="number" step="any" id="creditCard"><br>
-    <label>Credit Card Status:</label>
-    <input type="text" id="creditCardStatus"><br>
-
-    <label>Borrowed Amount:</label>
-    <input type="number" step="any" id="borrowedAmount"><br>
-    <label>Debt Recovered:</label>
-    <input type="number" step="any" id="debtRecovered"><br>
-    <label>Borrower:</label>
-    <input type="text" id="borrower"><br>
-
-    <label>Bad Handling:</label>
-    <input type="number" step="any" id="badHandling"><br>
-    <label>Expenses:</label>
-    <input type="number" step="any" id="expenses"><br><br>
-
-    <button type="submit">Submit Collections</button>
-</form>
+        <button type="submit" class="btn btn-success float-end">Submit Collections</button>
+    </form>
+</div>
 
 </body>
 </html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Dashboard Entry</title>
+    <script>
+        function collectProducts() {
+            const productGroups = document.querySelectorAll(".product-group");
+            const products = [];
+
+            productGroups.forEach(group => {
+                const inputs = group.querySelectorAll("input");
+                const product = {
+                    productName: inputs[0].value,
+                    subProduct: inputs[1].value,
+                    opening: parseFloat(inputs[2].value || 0),
+                    closing: parseFloat(inputs[3].value || 0),
+                    price: parseFloat(inputs[4].value),
+                    testing: parseFloat(inputs[5].value || 0)
+                };
+                products.push(product);
+            });
+
+            return products;
+        }
+
+        function submitSalesForm(event) {
+            event.preventDefault();
+
+            const salesData = {
+                date: document.getElementById("salesDate").value,
+                employeeId: parseInt(document.getElementById("salesEmployeeId").value),
+                products: collectProducts()
+            };
+
+            fetch('/sales', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(salesData)
+            })
+            .then(res => res.text())
+            .then(msg => alert("Sales Submitted: " + msg))
+            .catch(err => alert("Sales Error: " + err));
+        }
+
+        function submitCollectionsForm(event) {
+            event.preventDefault();
+
+            const collectionsData = {
+                date: document.getElementById("collectionsDate").value,
+                employeeId: parseInt(document.getElementById("collectionsEmployeeId").value),
+                cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
+                cashReceivedStatus: document.getElementById("cashReceivedStatus").value,
+                phonePay: parseFloat(document.getElementById("phonePay").value || 0),
+                phonePayStatus: document.getElementById("phonePayStatus").value,
+                creditCard: parseFloat(document.getElementById("creditCard").value || 0),
+                creditCardStatus: document.getElementById("creditCardStatus").value,
+                borrowedAmount: parseFloat(document.getElementById("borrowedAmount").value || 0),
+                debtRecovered: parseFloat(document.getElementById("debtRecovered").value || 0),
+                borrower: document.getElementById("borrower").value,
+                badHandling: parseFloat(document.getElementById("badHandling").value || 0),
+                expenses: parseFloat(document.getElementById("expenses").value || 0)
+            };
+
+            fetch('/collections', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(collectionsData)
+            })
+            .then(res => res.text())
+            .then(msg => alert("Collections Submitted: " + msg))
+            .catch(err => alert("Collections Error: " + err));
+        }
+
+        function addProductRow() {
+            const container = document.getElementById("products");
+
+            const div = document.createElement("div");
+            div.className = "product-group";
+            div.innerHTML = `
+                <hr>
+                <label>Product Name:</label>
+                <input type="text" required><br>
+                <label>Sub Product:</label>
+                <input type="text"><br>
+                <label>Opening:</label>
+                <input type="number" step="any"><br>
+                <label>Closing:</label>
+                <input type="number" step="any"><br>
+                <label>Price:</label>
+                <input type="number" step="any" required><br>
+                <label>Testing:</label>
+                <input type="number" step="any"><br>
+            `;
+            container.appendChild(div);
+        }
+
+        window.onload = () => {
+            addProductRow(); // default one product row
+        };
+    </script>
+</head>
+<body>
+
+<h1>Dashboard Entry</h1>
+
+<!-- Sales Entry Form -->
+<h2>Sales Entry</h2>
+<form id="salesForm" onsubmit="submitSalesForm(event)">
+    <label>Date:</label>
+    <input type="text" id="salesDate" required><br>
+
+    <label>Employee ID:</label>
+    <input type="number" id="salesEmployeeId" required><br>
+
+    <div id="products"></div>
+    <button type="button" onclick="addProductRow()">Add Product</button><br><br>
+
+    <button type="submit">Submit Sales</button>
+</form>
+
+<hr>
+
+<!-- Collections Entry Form -->
+<h2>Collections Entry</h2>
+<form id="collectionsForm" onsubmit="submitCollectionsForm(event)">
+    <label>Date:</label>
+    <input type="text" id="collectionsDate" required><br>
+
+    <label>Employee ID:</label>
+    <input type="number" id="collectionsEmployeeId" required><br>
+
+    <label>Cash Received:</label>
+    <input type="number" step="any" id="cashReceived"><br>
+    <label>Cash Received Status:</label>
+    <input type="text" id="cashReceivedStatus"><br>
+
+    <label>PhonePay:</label>
+    <input type="number" step="any" id="phonePay"><br>
+    <label>PhonePay Status:</label>
+    <input type="text" id="phonePayStatus"><br>
+
+    <label>Credit Card:</label>
+    <input type="number" step="any" id="creditCard"><br>
+    <label>Credit Card Status:</label>
+    <input type="text" id="creditCardStatus"><br>
+
+    <label>Borrowed Amount:</label>
+    <input type="number" step="any" id="borrowedAmount"><br>
+    <label>Debt Recovered:</label>
+    <input type="number" step="any" id="debtRecovered"><br>
+    <label>Borrower:</label>
+    <input type="text" id="borrower"><br>
+
+    <label>Bad Handling:</label>
+    <input type="number" step="any" id="badHandling"><br>
+    <label>Expenses:</label>
+    <input type="number" step="any" id="expenses"><br><br>
+
+    <button type="submit">Submit Collections</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,167 +1,156 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Sales & Collections Entry</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script>
-         function addProductRow() {
-        const container = document.getElementById("products");
-        const div = document.createElement("div");
-        div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
-
-        div.innerHTML = `
-            <div class="col-md-4">
-                <input type="text" class="form-control" placeholder="Product Name" required>
-            </div>
-            <div class="col-md-4">
-                <input type="text" class="form-control" placeholder="Sub Product">
-            </div>
-            <div class="col-md-2">
-                <input type="number" step="any" class="form-control" placeholder="Opening">
-            </div>
-            <div class="col-md-2">
-                <input type="number" step="any" class="form-control" placeholder="Closing">
-            </div>
-            <div class="col-md-4">
-                <input type="number" step="any" class="form-control" placeholder="Price" required>
-            </div>
-            <div class="col-md-4">
-                <input type="number" step="any" class="form-control" placeholder="Testing">
-            </div>
-            <div class="col-md-4 text-end">
-                <button type="button" class="btn btn-outline-danger btn-sm mt-2" onclick="removeProductRow(this)">Remove</button>
-            </div>
-        `;
-
-        container.appendChild(div);
-    }
-
-    function removeProductRow(button) {
-        button.closest('.product-group').remove();
-    }
-
-        function collectProducts() {
-            const groups = document.querySelectorAll(".product-group");
-            const products = [];
-
-            groups.forEach(group => {
-                const inputs = group.querySelectorAll("input");
-                products.push({
-                    productName: inputs[0].value,
-                    subProduct: inputs[1].value,
-                    opening: parseFloat(inputs[2].value || 0),
-                    closing: parseFloat(inputs[3].value || 0),
-                    price: parseFloat(inputs[4].value),
-                    testing: parseFloat(inputs[5].value || 0)
-                });
-            });
-
-            return products;
-        }
-
-        function submitSales(event) {
-        
-            event.preventDefault();
-            const data = {
-                date: document.getElementById("salesDate").value,
-                employeeId: parseInt(document.getElementById("salesEmployeeId").value),
-                products: collectProducts()
-            };
-
-            fetch('/sales', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            }).then(res => res.text())
-              .then(msg => alert("Sales Saved: " + msg))
-              .catch(err => alert("Error: " + err));
-        }
-
-        function submitCollections(event) {
-            event.preventDefault();
-            const data = {
-                date: document.getElementById("collectionsDate").value,
-                employeeId: parseInt(document.getElementById("collectionsEmployeeId").value),
-                cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
-                cashReceivedStatus: document.getElementById("cashReceivedStatus").value,
-                phonePay: parseFloat(document.getElementById("phonePay").value || 0),
-                phonePayStatus: document.getElementById("phonePayStatus").value,
-                creditCard: parseFloat(document.getElementById("creditCard").value || 0),
-                creditCardStatus: document.getElementById("creditCardStatus").value,
-                borrowedAmount: parseFloat(document.getElementById("borrowedAmount").value || 0),
-                debtRecovered: parseFloat(document.getElementById("debtRecovered").value || 0),
-                borrower: document.getElementById("borrower").value,
-                badHandling: parseFloat(document.getElementById("badHandling").value || 0),
-                expenses: parseFloat(document.getElementById("expenses").value || 0)
-            };
-
-            fetch('/collections', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            }).then(res => res.text())
-              .then(msg => alert("Collections Saved: " + msg))
-              .catch(err => alert("Error: " + err));
-        }
-
-        window.onload = () => addProductRow();
-    </script>
+    <title>Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body class="bg-body-tertiary">
-
+<body>
 <div class="container py-4">
-    <h2 class="mb-4">Sales & Collections Dashboard</h2>
 
-    <!-- Sales Form -->
-    <form onsubmit="submitSales(event)" class="mb-5 border p-4 rounded bg-white shadow-sm">
-        <h4>Sales Entry</h4>
-        <div class="row g-3 mb-3">
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="salesDate" placeholder="Date" required>
-            </div>
-            <div class="col-md-6">
-                <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
-            </div>
+    <h2>Dashboard</h2>
+
+    <div class="mb-4 d-flex gap-3">
+        <button class="btn btn-outline-primary" onclick="loadReport('daily')">Today</button>
+        <button class="btn btn-outline-secondary" onclick="loadReport('weekly')">This Week</button>
+        <button class="btn btn-outline-success" onclick="loadReport('monthly')">This Month</button>
+    </div>
+
+    <form id="customRangeForm" class="row g-3 mb-4" onsubmit="event.preventDefault(); loadCustomReport();">
+        <div class="col-md-5">
+            <label for="fromDateTime" class="form-label">From</label>
+            <input type="datetime-local" id="fromDateTime" name="fromDateTime" class="form-control" required />
         </div>
-
-        <div id="products"></div>
-        <button type="button" class="btn btn-outline-primary mt-2" onclick="addProductRow()">Add Product</button>
-        <button type="submit" class="btn btn-success mt-2 float-end">Submit Sales</button>
+        <div class="col-md-5">
+            <label for="toDateTime" class="form-label">To</label>
+            <input type="datetime-local" id="toDateTime" name="toDateTime" class="form-control" required />
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary w-100">Generate Custom Report</button>
+        </div>
     </form>
 
-    <!-- Collections Form -->
-    <form onsubmit="submitCollections(event)" class="border p-4 rounded bg-white shadow-sm">
-        <h4>Collections Entry</h4>
-        <div class="row g-3 mb-3">
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="collectionsDate" placeholder="Date" required>
-            </div>
-            <div class="col-md-6">
-                <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
-            </div>
-        </div>
+    <div id="reportContainer" class="mt-4">
+        <h5>Sales Report</h5>
+        <p><strong>From:</strong> <span id="reportFrom"></span></p>
+        <p><strong>To:</strong> <span id="reportTo"></span></p>
+        <table class="table table-bordered table-striped mt-3">
+            <tbody>
+            <tr><td>Actual Collection</td><td id="actualCollection"></td></tr>
+            <tr><td>Difference</td><td id="difference"></td></tr>
+            <tr><td>Petrol Sale (L)</td><td id="petrolSale"></td></tr>
+            <tr><td>Petrol Expected</td><td id="petrolExpected"></td></tr>
+            <tr><td>Diesel Sale (L)</td><td id="dieselSale"></td></tr>
+            <tr><td>Diesel Expected</td><td id="dieselExpected"></td></tr>
+            </tbody>
+        </table>
+    </div>
 
-        <div class="row g-3 mb-3">
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status"></div>
-
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status"></div>
-
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status"></div>
-
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered"></div>
-
-            <div class="col-md-6"><input type="text" class="form-control" id="borrower" placeholder="Borrower Name"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses"></div>
-        </div>
-
-        <button type="submit" class="btn btn-success float-end">Submit Collections</button>
-    </form>
 </div>
 
+<script>
+    // Utility: format ISO string to readable datetime-local input format (yyyy-MM-ddTHH:mm)
+    function toInputDateTimeFormat(date) {
+        const d = new Date(date);
+        d.setMinutes(d.getMinutes() - d.getTimezoneOffset()); // Adjust for timezone offset
+        return d.toISOString().slice(0,16);
+    }
+
+    // Format date for display (simple)
+    function formatDisplayDate(date) {
+        return new Date(date).toLocaleString();
+    }
+
+   function pad(n) {
+    return n < 10 ? '0' + n : n;
+}
+
+function formatDateToCustomString(date) {
+    return pad(date.getDate()) + '-' +    // day
+           pad(date.getMonth() + 1) + '-' +  // month (0-based +1)
+           date.getFullYear() + ' ' +    // year
+           pad(date.getHours()) + ':' +  // hours 00-23
+           pad(date.getMinutes()) + ':' +  // minutes
+           pad(date.getSeconds());         // seconds
+}
+
+function loadReport(range) {
+    let fromDate, toDate;
+    const now = new Date();
+
+    if (range === 'daily') {
+        fromDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+        toDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59);
+    } else if (range === 'weekly') {
+        const day = now.getDay() || 7; // Sunday=0, treat as 7
+        const monday = new Date(now);
+        monday.setDate(now.getDate() - day + 1);
+        fromDate = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate(), 0, 0, 0);
+        toDate = now;
+    } else if (range === 'monthly') {
+        fromDate = new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0);
+        toDate = now;
+    }
+
+    const formattedFrom = formatDateToCustomString(fromDate);
+    const formattedTo = formatDateToCustomString(toDate);
+
+    fetchReport(formattedFrom, formattedTo);
+}
+
+        function loadCustomReport() {
+    const fromInput = document.getElementById('fromDateTime').value;
+    const toInput = document.getElementById('toDateTime').value;
+
+    if (!fromInput || !toInput) {
+        alert("Please select both From and To dates");
+        return;
+    }
+
+    const fromDate = new Date(fromInput);
+    const toDate = new Date(toInput);
+
+    const formattedFrom = formatDateToCustomString(fromDate);
+    const formattedTo = formatDateToCustomString(toDate);
+
+    fetchReport(formattedFrom, formattedTo);
+}
+
+    function fetchReport(fromStr, toStr) {
+    fetch('/dashboard-data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            fromDate: fromStr,  // e.g. "17-05-2025 00:00:00"
+            toDate: toStr       // e.g. "17-05-2025 23:59:59"
+        })
+    })
+    .then(res => res.json())
+    .then(data => {
+  // Show the from and to dates (display formatted)
+        document.getElementById('reportFrom').textContent = fromStr;
+        document.getElementById('reportTo').textContent = toStr;
+
+        // Update your report values (assuming numbers)
+        document.getElementById('actualCollection').textContent = data.actualCollection.toFixed(2);
+        document.getElementById('difference').textContent = data.difference.toFixed(2);
+
+        document.getElementById('petrolSale').textContent = data.petrol.saleInLtr.toFixed(4);
+        document.getElementById('petrolExpected').textContent = data.petrol.expectedCollections.toFixed(2);
+
+        document.getElementById('dieselSale').textContent = data.diesel.saleInLtr.toFixed(4);
+        document.getElementById('dieselExpected').textContent = data.diesel.expectedCollections.toFixed(2);
+    })
+    .catch(err => {
+        console.error(err);
+        alert('Failed to load report data.');
+    });
+}
+
+
+    // Load daily report on page load by default
+    window.onload = () => {
+        loadReport('daily');
+    };
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -4,55 +4,72 @@
     <title>Sales & Collections Entry</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <script>
-         function addProductRow() {
-        const container = document.getElementById("products");
-        const div = document.createElement("div");
-        div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
+        function addProductRow() {
+            const container = document.getElementById("products");
+            const div = document.createElement("div");
+            div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
 
-        div.innerHTML = `
-            <div class="col-md-4">
-                <input type="text" class="form-control" placeholder="Product Name" required>
-            </div>
-            <div class="col-md-4">
-                <input type="text" class="form-control" placeholder="Sub Product">
-            </div>
-            <div class="col-md-2">
-                <input type="number" step="any" class="form-control" placeholder="Opening">
-            </div>
-            <div class="col-md-2">
-                <input type="number" step="any" class="form-control" placeholder="Closing">
-            </div>
-            <div class="col-md-4">
-                <input type="number" step="any" class="form-control" placeholder="Price" required>
-            </div>
-            <div class="col-md-4">
-                <input type="number" step="any" class="form-control" placeholder="Testing">
-            </div>
-            <div class="col-md-4 text-end">
-                <button type="button" class="btn btn-outline-danger btn-sm mt-2" onclick="removeProductRow(this)">Remove</button>
-            </div>
-        `;
+            div.innerHTML = `
+                <div class="col-md-4">
+                    <select class="form-control" required>
+                        <option value="" disabled selected>Select Product</option>
+                        <option value="petrol">Petrol</option>
+                        <option value="diesel">Diesel</option>
+                        <option value="other">Other</option>
+                    </select>
+                </div>
+                <!-- Sub-Product is now a dropdown of G1, G2, G3 -->
+                <div class="col-md-4">
+                    <select class="form-control" required>
+                        <option value="" disabled selected>Select Sub-Product</option>
+                        <option value="G1">G1</option>
+                        <option value="G2">G2</option>
+                        <option value="G3">G3</option>
+                    </select>
+                </div>
 
-        container.appendChild(div);
-    }
+                <div class="col-md-2">
+                    <input type="number" step="any" class="form-control" placeholder="Opening">
+                </div>
+                <div class="col-md-2">
+                    <input type="number" step="any" class="form-control" placeholder="Closing">
+                </div>
+                <div class="col-md-4">
+                    <input type="number" step="any" class="form-control" placeholder="Price" required>
+                </div>
+                <div class="col-md-4">
+                    <input type="number" step="any" class="form-control" placeholder="Testing">
+                </div>
+                <div class="col-12 d-flex justify-content-end">
+                    <button type="button"
+                            class="btn btn-outline-danger btn-sm mt-2"
+                            onclick="removeProductRow(this)">
+                        Remove
+                    </button>
+                </div>
+            `;
+            container.appendChild(div);
+        }
 
-    function removeProductRow(button) {
-        button.closest('.product-group').remove();
-    }
+        function removeProductRow(button) {
+            button.closest('.product-group').remove();
+        }
 
         function collectProducts() {
             const groups = document.querySelectorAll(".product-group");
             const products = [];
 
             groups.forEach(group => {
-                const inputs = group.querySelectorAll("input");
+                // New fields order: select(product), select(subProduct), input(opening), input(closing), input(price), input(testing)
+                const fields = group.querySelectorAll("select, input");
+
                 products.push({
-                    productName: inputs[0].value,
-                    subProduct: inputs[1].value,
-                    opening: parseFloat(inputs[2].value || 0),
-                    closing: parseFloat(inputs[3].value || 0),
-                    price: parseFloat(inputs[4].value),
-                    testing: parseFloat(inputs[5].value || 0)
+                    productName: fields[0].value,
+                    subProduct:   fields[1].value,
+                    opening:      parseFloat(fields[2].value || 0),
+                    closing:      parseFloat(fields[3].value || 0),
+                    price:        parseFloat(fields[4].value),
+                    testing:      parseFloat(fields[5].value || 0)
                 });
             });
 
@@ -60,7 +77,6 @@
         }
 
         function submitSales(event) {
-        
             event.preventDefault();
             const data = {
                 date: document.getElementById("salesDate").value,
@@ -72,9 +88,10 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data)
-            }).then(res => res.text())
-              .then(msg => alert("Sales Saved: " + msg))
-              .catch(err => alert("Error: " + err));
+            })
+            .then(res => res.text())
+            .then(msg => alert("Sales Saved: " + msg))
+            .catch(err => alert("Error: " + err));
         }
 
         function submitCollections(event) {
@@ -99,9 +116,10 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data)
-            }).then(res => res.text())
-              .then(msg => alert("Collections Saved: " + msg))
-              .catch(err => alert("Error: " + err));
+            })
+            .then(res => res.text())
+            .then(msg => alert("Collections Saved: " + msg))
+            .catch(err => alert("Error: " + err));
         }
 
         window.onload = () => addProductRow();
@@ -117,7 +135,7 @@
         <h4>Sales Entry</h4>
         <div class="row g-3 mb-3">
             <div class="col-md-6">
-                <input type="text" class="form-control" id="salesDate" placeholder="Date" required>
+                <input type="date" class="form-control" id="salesDate" required>
             </div>
             <div class="col-md-6">
                 <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
@@ -134,7 +152,7 @@
         <h4>Collections Entry</h4>
         <div class="row g-3 mb-3">
             <div class="col-md-6">
-                <input type="text" class="form-control" id="collectionsDate" placeholder="Date" required>
+                <input type="date" class="form-control" id="collectionsDate" required>
             </div>
             <div class="col-md-6">
                 <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
@@ -142,21 +160,43 @@
         </div>
 
         <div class="row g-3 mb-3">
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status"></div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received">
+            </div>
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status">
+            </div>
 
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status"></div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay">
+            </div>
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status">
+            </div>
 
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card"></div>
-            <div class="col-md-6"><input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status"></div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card">
+            </div>
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status">
+            </div>
 
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered"></div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount">
+            </div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered">
+            </div>
 
-            <div class="col-md-6"><input type="text" class="form-control" id="borrower" placeholder="Borrower Name"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling"></div>
-            <div class="col-md-6"><input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses"></div>
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="borrower" placeholder="Borrower Name">
+            </div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling">
+            </div>
+            <div class="col-md-6">
+                <input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses">
+            </div>
         </div>
 
         <button type="submit" class="btn btn-success float-end">Submit Collections</button>
@@ -165,3 +205,4 @@
 
 </body>
 </html>
+

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -1,208 +1,212 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Sales & Collections Entry</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script>
-        function addProductRow() {
-            const container = document.getElementById("products");
-            const div = document.createElement("div");
-            div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
+  <title>Sales & Collections Entry</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  >
+  <script>
+    function addProductRow() {
+      const container = document.getElementById("products");
+      const div = document.createElement("div");
+      div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
 
-            div.innerHTML = `
-                <div class="col-md-4">
-                    <select class="form-control" required>
-                        <option value="" disabled selected>Select Product</option>
-                        <option value="petrol">Petrol</option>
-                        <option value="diesel">Diesel</option>
-                        <option value="other">Other</option>
-                    </select>
-                </div>
-                <!-- Sub-Product is now a dropdown of G1, G2, G3 -->
-                <div class="col-md-4">
-                    <select class="form-control" required>
-                        <option value="" disabled selected>Select Sub-Product</option>
-                        <option value="G1">G1</option>
-                        <option value="G2">G2</option>
-                        <option value="G3">G3</option>
-                    </select>
-                </div>
+      div.innerHTML = `
+        <div class="col-md-4">
+          <select name="product" class="form-control" required>
+            <option value="" disabled selected>Select Product</option>
+            <option value="petrol">Petrol</option>
+            <option value="diesel">Diesel</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <select name="subProduct" class="form-control" required>
+            <option value="" disabled selected>Select Sub-Product</option>
+            <option value="G1">G1</option>
+            <option value="G2">G2</option>
+            <option value="G3">G3</option>
+          </select>
+        </div>
+        <div class="col-md-2">
+          <input name="opening" type="number" step="any" class="form-control" placeholder="Opening">
+        </div>
+        <div class="col-md-2">
+          <input name="closing" type="number" step="any" class="form-control" placeholder="Closing">
+        </div>
+        <div class="col-md-4">
+          <input name="price" type="number" step="any" class="form-control" placeholder="Price" required>
+        </div>
+        <div class="col-md-4">
+          <input name="testing" type="number" step="any" class="form-control" placeholder="Testing">
+        </div>
+        <div class="col-12 d-flex justify-content-end">
+          <button
+            type="button"
+            class="btn btn-outline-danger btn-sm mt-2"
+            onclick="removeProductRow(this)">
+            Remove
+          </button>
+        </div>
+      `;
+      container.appendChild(div);
 
-                <div class="col-md-2">
-                    <input type="number" step="any" class="form-control" placeholder="Opening">
-                </div>
-                <div class="col-md-2">
-                    <input type="number" step="any" class="form-control" placeholder="Closing">
-                </div>
-                <div class="col-md-4">
-                    <input type="number" step="any" class="form-control" placeholder="Price" required>
-                </div>
-                <div class="col-md-4">
-                    <input type="number" step="any" class="form-control" placeholder="Testing">
-                </div>
-                <div class="col-12 d-flex justify-content-end">
-                    <button type="button"
-                            class="btn btn-outline-danger btn-sm mt-2"
-                            onclick="removeProductRow(this)">
-                        Remove
-                    </button>
-                </div>
-            `;
-            container.appendChild(div);
-        }
+      // Auto‐fill Opening from last Closing
+      const prod = div.querySelector('select[name="product"]');
+      const sub  = div.querySelector('select[name="subProduct"]');
+      const open = div.querySelector('input[name="opening"]');
 
-        function removeProductRow(button) {
-            button.closest('.product-group').remove();
-        }
+      function updateOpening() {
+        if (!prod.value || !sub.value) return;
+        fetch(
+          `/sales/last?productName=${encodeURIComponent(prod.value)}&subProduct=${encodeURIComponent(sub.value)}`
+        )
+          .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+          .then(d => { open.value = d.lastClosing; })
+          .catch(console.error);
+      }
 
-        function collectProducts() {
-            const groups = document.querySelectorAll(".product-group");
-            const products = [];
+      prod.addEventListener("change", updateOpening);
+      sub .addEventListener("change", updateOpening);
+    }
 
-            groups.forEach(group => {
-                // New fields order: select(product), select(subProduct), input(opening), input(closing), input(price), input(testing)
-                const fields = group.querySelectorAll("select, input");
+    function removeProductRow(btn) {
+      btn.closest(".product-group").remove();
+    }
 
-                products.push({
-                    productName: fields[0].value,
-                    subProduct:   fields[1].value,
-                    opening:      parseFloat(fields[2].value || 0),
-                    closing:      parseFloat(fields[3].value || 0),
-                    price:        parseFloat(fields[4].value),
-                    testing:      parseFloat(fields[5].value || 0)
-                });
-            });
+    function collectProducts() {
+      return Array.from(document.querySelectorAll(".product-group")).map(group => {
+        const f = group.querySelectorAll("select, input");
+        return {
+          productName: f[0].value,
+          subProduct:  f[1].value,
+          opening:     parseFloat(f[2].value || 0),
+          closing:     parseFloat(f[3].value || 0),
+          price:       parseFloat(f[4].value),
+          testing:     parseFloat(f[5].value || 0)
+        };
+      });
+    }
 
-            return products;
-        }
+    function submitSales(e) {
+      e.preventDefault();
+      const payload = {
+        date:        document.getElementById("salesDate").value,
+        employeeId:  +document.getElementById("salesEmployeeId").value,
+        products:    collectProducts()
+      };
+      fetch("/sales", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify(payload)
+      })
+      .then(r => r.text())
+      .then(msg => alert("Sales Saved: " + msg))
+      .catch(err => alert("Error: " + err));
+    }
 
-        function submitSales(event) {
-            event.preventDefault();
-            const data = {
-                date: document.getElementById("salesDate").value,
-                employeeId: parseInt(document.getElementById("salesEmployeeId").value),
-                products: collectProducts()
-            };
+    function submitCollections(e) {
+      e.preventDefault();
+      const payload = {
+        date:                document.getElementById("collectionsDate").value,
+        employeeId:          +document.getElementById("collectionsEmployeeId").value,
+        cashReceived:        parseFloat(document.getElementById("cashReceived").value || 0),
+        cashReceivedStatus:  document.getElementById("cashReceivedStatus").value,
+        phonePay:            parseFloat(document.getElementById("phonePay").value || 0),
+        phonePayStatus:      document.getElementById("phonePayStatus").value,
+        creditCard:          parseFloat(document.getElementById("creditCard").value || 0),
+        creditCardStatus:    document.getElementById("creditCardStatus").value,
+        borrowedAmount:      parseFloat(document.getElementById("borrowedAmount").value || 0),
+        debtRecovered:       parseFloat(document.getElementById("debtRecovered").value || 0),
+        borrower:            document.getElementById("borrower").value,
+        badHandling:         parseFloat(document.getElementById("badHandling").value || 0),
+        expenses:            parseFloat(document.getElementById("expenses").value || 0)
+      };
+      fetch("/collections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify(payload)
+      })
+      .then(r => r.text())
+      .then(msg => alert("Collections Saved: " + msg))
+      .catch(err => alert("Error: " + err));
+    }
 
-            fetch('/sales', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            })
-            .then(res => res.text())
-            .then(msg => alert("Sales Saved: " + msg))
-            .catch(err => alert("Error: " + err));
-        }
-
-        function submitCollections(event) {
-            event.preventDefault();
-            const data = {
-                date: document.getElementById("collectionsDate").value,
-                employeeId: parseInt(document.getElementById("collectionsEmployeeId").value),
-                cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
-                cashReceivedStatus: document.getElementById("cashReceivedStatus").value,
-                phonePay: parseFloat(document.getElementById("phonePay").value || 0),
-                phonePayStatus: document.getElementById("phonePayStatus").value,
-                creditCard: parseFloat(document.getElementById("creditCard").value || 0),
-                creditCardStatus: document.getElementById("creditCardStatus").value,
-                borrowedAmount: parseFloat(document.getElementById("borrowedAmount").value || 0),
-                debtRecovered: parseFloat(document.getElementById("debtRecovered").value || 0),
-                borrower: document.getElementById("borrower").value,
-                badHandling: parseFloat(document.getElementById("badHandling").value || 0),
-                expenses: parseFloat(document.getElementById("expenses").value || 0)
-            };
-
-            fetch('/collections', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            })
-            .then(res => res.text())
-            .then(msg => alert("Collections Saved: " + msg))
-            .catch(err => alert("Error: " + err));
-        }
-
-        window.onload = () => addProductRow();
-    </script>
+    window.onload = () => addProductRow();
+  </script>
 </head>
 <body class="bg-body-tertiary">
-
-<div class="container py-4">
+  <div class="container py-4">
     <h2 class="mb-4">Sales & Collections Dashboard</h2>
 
     <!-- Sales Form -->
     <form onsubmit="submitSales(event)" class="mb-5 border p-4 rounded bg-white shadow-sm">
-        <h4>Sales Entry</h4>
-        <div class="row g-3 mb-3">
-            <div class="col-md-6">
-                <input type="date" class="form-control" id="salesDate" required>
-            </div>
-            <div class="col-md-6">
-                <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
-            </div>
+      <h4>Sales Entry</h4>
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <input type="date" class="form-control" id="salesDate" required>
         </div>
-
-        <div id="products"></div>
-        <button type="button" class="btn btn-outline-primary mt-2" onclick="addProductRow()">Add Product</button>
-        <button type="submit" class="btn btn-success mt-2 float-end">Submit Sales</button>
+        <div class="col-md-6">
+          <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
+        </div>
+      </div>
+      <div id="products"></div>
+      <button type="button" class="btn btn-outline-primary mt-2" onclick="addProductRow()">Add Product</button>
+      <button type="submit" class="btn btn-success mt-2 float-end">Submit Sales</button>
     </form>
 
     <!-- Collections Form -->
     <form onsubmit="submitCollections(event)" class="border p-4 rounded bg-white shadow-sm">
-        <h4>Collections Entry</h4>
-        <div class="row g-3 mb-3">
-            <div class="col-md-6">
-                <input type="date" class="form-control" id="collectionsDate" required>
-            </div>
-            <div class="col-md-6">
-                <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
-            </div>
+      <h4>Collections Entry</h4>
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <input type="date" class="form-control" id="collectionsDate" required>
         </div>
-
-        <div class="row g-3 mb-3">
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received">
-            </div>
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status">
-            </div>
-
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay">
-            </div>
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status">
-            </div>
-
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card">
-            </div>
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status">
-            </div>
-
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount">
-            </div>
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered">
-            </div>
-
-            <div class="col-md-6">
-                <input type="text" class="form-control" id="borrower" placeholder="Borrower Name">
-            </div>
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling">
-            </div>
-            <div class="col-md-6">
-                <input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses">
-            </div>
+        <div class="col-md-6">
+          <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
         </div>
-
-        <button type="submit" class="btn btn-success float-end">Submit Collections</button>
+      </div>
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received">
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay">
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card">
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered">
+        </div>
+        <div class="col-md-6">
+          <input type="text" class="form-control" id="borrower" placeholder="Borrower Name">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling">
+        </div>
+        <div class="col-md-6">
+          <input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses">
+        </div>
+      </div>
+      <button type="submit" class="btn btn-success float-end">Submit Collections</button>
     </form>
-</div>
 
+  </div>
 </body>
 </html>
+
 

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Sales & Collections Entry</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script>
+         function addProductRow() {
+        const container = document.getElementById("products");
+        const div = document.createElement("div");
+        div.className = "row g-2 mb-3 product-group border rounded p-3 bg-light position-relative";
+
+        div.innerHTML = `
+            <div class="col-md-4">
+                <input type="text" class="form-control" placeholder="Product Name" required>
+            </div>
+            <div class="col-md-4">
+                <input type="text" class="form-control" placeholder="Sub Product">
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="any" class="form-control" placeholder="Opening">
+            </div>
+            <div class="col-md-2">
+                <input type="number" step="any" class="form-control" placeholder="Closing">
+            </div>
+            <div class="col-md-4">
+                <input type="number" step="any" class="form-control" placeholder="Price" required>
+            </div>
+            <div class="col-md-4">
+                <input type="number" step="any" class="form-control" placeholder="Testing">
+            </div>
+            <div class="col-md-4 text-end">
+                <button type="button" class="btn btn-outline-danger btn-sm mt-2" onclick="removeProductRow(this)">Remove</button>
+            </div>
+        `;
+
+        container.appendChild(div);
+    }
+
+    function removeProductRow(button) {
+        button.closest('.product-group').remove();
+    }
+
+        function collectProducts() {
+            const groups = document.querySelectorAll(".product-group");
+            const products = [];
+
+            groups.forEach(group => {
+                const inputs = group.querySelectorAll("input");
+                products.push({
+                    productName: inputs[0].value,
+                    subProduct: inputs[1].value,
+                    opening: parseFloat(inputs[2].value || 0),
+                    closing: parseFloat(inputs[3].value || 0),
+                    price: parseFloat(inputs[4].value),
+                    testing: parseFloat(inputs[5].value || 0)
+                });
+            });
+
+            return products;
+        }
+
+        function submitSales(event) {
+        
+            event.preventDefault();
+            const data = {
+                date: document.getElementById("salesDate").value,
+                employeeId: parseInt(document.getElementById("salesEmployeeId").value),
+                products: collectProducts()
+            };
+
+            fetch('/sales', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            }).then(res => res.text())
+              .then(msg => alert("Sales Saved: " + msg))
+              .catch(err => alert("Error: " + err));
+        }
+
+        function submitCollections(event) {
+            event.preventDefault();
+            const data = {
+                date: document.getElementById("collectionsDate").value,
+                employeeId: parseInt(document.getElementById("collectionsEmployeeId").value),
+                cashReceived: parseFloat(document.getElementById("cashReceived").value || 0),
+                cashReceivedStatus: document.getElementById("cashReceivedStatus").value,
+                phonePay: parseFloat(document.getElementById("phonePay").value || 0),
+                phonePayStatus: document.getElementById("phonePayStatus").value,
+                creditCard: parseFloat(document.getElementById("creditCard").value || 0),
+                creditCardStatus: document.getElementById("creditCardStatus").value,
+                borrowedAmount: parseFloat(document.getElementById("borrowedAmount").value || 0),
+                debtRecovered: parseFloat(document.getElementById("debtRecovered").value || 0),
+                borrower: document.getElementById("borrower").value,
+                badHandling: parseFloat(document.getElementById("badHandling").value || 0),
+                expenses: parseFloat(document.getElementById("expenses").value || 0)
+            };
+
+            fetch('/collections', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            }).then(res => res.text())
+              .then(msg => alert("Collections Saved: " + msg))
+              .catch(err => alert("Error: " + err));
+        }
+
+        window.onload = () => addProductRow();
+    </script>
+</head>
+<body class="bg-body-tertiary">
+
+<div class="container py-4">
+    <h2 class="mb-4">Sales & Collections Dashboard</h2>
+
+    <!-- Sales Form -->
+    <form onsubmit="submitSales(event)" class="mb-5 border p-4 rounded bg-white shadow-sm">
+        <h4>Sales Entry</h4>
+        <div class="row g-3 mb-3">
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="salesDate" placeholder="Date" required>
+            </div>
+            <div class="col-md-6">
+                <input type="number" class="form-control" id="salesEmployeeId" placeholder="Employee ID" required>
+            </div>
+        </div>
+
+        <div id="products"></div>
+        <button type="button" class="btn btn-outline-primary mt-2" onclick="addProductRow()">Add Product</button>
+        <button type="submit" class="btn btn-success mt-2 float-end">Submit Sales</button>
+    </form>
+
+    <!-- Collections Form -->
+    <form onsubmit="submitCollections(event)" class="border p-4 rounded bg-white shadow-sm">
+        <h4>Collections Entry</h4>
+        <div class="row g-3 mb-3">
+            <div class="col-md-6">
+                <input type="text" class="form-control" id="collectionsDate" placeholder="Date" required>
+            </div>
+            <div class="col-md-6">
+                <input type="number" class="form-control" id="collectionsEmployeeId" placeholder="Employee ID" required>
+            </div>
+        </div>
+
+        <div class="row g-3 mb-3">
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="cashReceived" placeholder="Cash Received"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="cashReceivedStatus" placeholder="Cash Received Status"></div>
+
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="phonePay" placeholder="Phone Pay"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="phonePayStatus" placeholder="Phone Pay Status"></div>
+
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="creditCard" placeholder="Credit Card"></div>
+            <div class="col-md-6"><input type="text" class="form-control" id="creditCardStatus" placeholder="Credit Card Status"></div>
+
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="borrowedAmount" placeholder="Borrowed Amount"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="debtRecovered" placeholder="Debt Recovered"></div>
+
+            <div class="col-md-6"><input type="text" class="form-control" id="borrower" placeholder="Borrower Name"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="badHandling" placeholder="Bad Handling"></div>
+            <div class="col-md-6"><input type="number" step="any" class="form-control" id="expenses" placeholder="Expenses"></div>
+        </div>
+
+        <button type="submit" class="btn btn-success float-end">Submit Collections</button>
+    </form>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/sales-form.html
+++ b/src/main/resources/templates/sales-form.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Sales Entry Form</title>
+    <script>
+        let productIndex = 0;
+
+        function addProductRow() {
+            const container = document.getElementById("products");
+
+            const div = document.createElement("div");
+            div.className = "product-group";
+            div.innerHTML = `
+                <hr>
+                <label>Product Name:</label>
+                <input type="text" name="productName" required><br>
+
+                <label>Sub Product:</label>
+                <input type="text" name="subProduct"><br>
+
+                <label>Opening:</label>
+                <input type="number" step="any" name="opening"><br>
+
+                <label>Closing:</label>
+                <input type="number" step="any" name="closing"><br>
+
+                <label>Price:</label>
+                <input type="number" step="any" name="price" required><br>
+
+                <label>Testing:</label>
+                <input type="number" step="any" name="testing"><br>
+            `;
+            container.appendChild(div);
+        }
+
+        function collectProducts() {
+            const productGroups = document.querySelectorAll(".product-group");
+            const products = [];
+
+            productGroups.forEach(group => {
+                const inputs = group.querySelectorAll("input");
+                const product = {
+                    productName: inputs[0].value,
+                    subProduct: inputs[1].value,
+                    opening: parseFloat(inputs[2].value || 0),
+                    closing: parseFloat(inputs[3].value || 0),
+                    price: parseFloat(inputs[4].value),
+                    testing: parseFloat(inputs[5].value || 0)
+                };
+                products.push(product);
+            });
+
+            return products;
+        }
+
+        function submitForm(event) {
+            event.preventDefault();
+
+            const entry = {
+                date: document.getElementById("date").value,
+                employeeId: parseInt(document.getElementById("employeeId").value),
+                products: collectProducts()
+            };
+
+            fetch('/sales', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(entry)
+            })
+            .then(response => response.text())
+            .then(msg => alert("Submitted: " + msg))
+            .catch(err => alert("Error: " + err));
+        }
+
+        window.onload = () => {
+            addProductRow(); // Add at least one row on page load
+        };
+    </script>
+</head>
+<body>
+<h1>Sales Entry</h1>
+
+<form id="salesForm" onsubmit="submitForm(event)">
+    <label>Date:</label>
+    <input type="text" id="date" name="date" required><br>
+
+    <label>Employee ID:</label>
+    <input type="number" id="employeeId" name="employeeId" required><br>
+
+    <h3>Products</h3>
+    <div id="products"></div>
+
+    <button type="button" onclick="addProductRow()">Add Another Product</button><br><br>
+    <button type="submit">Submit</button>
+</form>
+
+</body>
+</html>

--- a/src/test/java/com/fos/reporting/ReportingApplicationTests.java
+++ b/src/test/java/com/fos/reporting/ReportingApplicationTests.java
@@ -1,0 +1,13 @@
+package com.fos.reporting;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ReportingApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
* Swapped the free-text date fields for native `<input type="date">` pickers, so users get a calendar widget and ISO date values.
* Turned the product name input into a Bootstrap dropdown for “Petrol/Diesel/Other.”
* Added a second dropdown next to it for “Sub-Product” options (G1, G2, G3).
* Updated the JavaScript to read both dropdown values plus Opening/Closing/Price/Testing in the correct order.
* Changed the back-end DTO to bind the new ISO date into a `LocalDate`.
* Refactored service methods to use `entryProduct.getDate().atStartOfDay()` and the updated field names.
